### PR TITLE
Update Github Build and Pack workflow

### DIFF
--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Retrieve Assimp Hash
       uses: theowenyoung/folder-hash@v3
       with:
-        path: ${{github.workspace}}/src/external/assimp
+        path: ${{github.workspace}}\src\external\assimp
       id: AssimpHash
 
     - name: Restore Assimp cache
@@ -41,29 +41,29 @@ jobs:
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Configure Assimp
-      working-directory: ${{github.workspace}}/src/external/assimp
+      working-directory: ${{github.workspace}}\src\external\assimp
       run: cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Build Assimp
-      working-directory: ${{github.workspace}}/src/external/assimp
+      working-directory: ${{github.workspace}}\src\external\assimp
       run: cmake --build . --config ${{env.BUILD_TYPE}}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}\build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
       
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}\build --config ${{env.BUILD_TYPE}}
 
     - name: Snatch the result
-      run: copy ${{github.workspace}}/build/bin/Release/*.exe  ${{github.workspace}}/bin
+      run: copy ${{github.workspace}}\build\bin\Release\*.exe  ${{github.workspace}}\bin
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: Clout-win-x64
-        path: ${{github.workspace}}/bin/*
+        path: ${{github.workspace}}\bin\*
 

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -1,5 +1,5 @@
 # This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml 
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
 name: Build and Pack
 
 on: 

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -30,7 +30,7 @@ jobs:
   # There's probably a better way to do this, but I'm not familiar enough with github
     - name: Retrieve Assimp SHA
       run: |
-        echo "ASSIMP_SHA=$(git ls-files -s src/external/assimp)" >> $GITHUB_OUTPUT
+        echo "ASSIMP_SHA=$(git ls-files -s ./src/external/assimp)" >> $GITHUB_OUTPUT
       id: AssimpSHA
 
     - name: Restore Assimp cache

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -30,7 +30,7 @@ jobs:
   # There's probably a better way to do this, but I'm not familiar enough with github
     - name: Retrieve Assimp SHA
       run: |
-        echo "ASSIMP_SHA=$(ls-files -s src/external/assimp)" >> $GITHUB_OUTPUT
+        echo "ASSIMP_SHA=$(git ls-files -s src/external/assimp)" >> $GITHUB_OUTPUT
       id: AssimpSHA
 
     - name: Restore Assimp cache

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -32,8 +32,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{github.workspace}}/src/external/assimp/lib/release/assimp-vc143-mt.lib
-          ${{github.workspace}}/src/external/assimp/include/assimp/config.h
+          ${{github.workspace}}\src\external\assimp\lib\release\assimp-vc143-mt.lib
+          ${{github.workspace}}\src\external\assimp\include\assimp\config.h
         #Use the currently active commit SHA as the key
         key: ${{ runner.os }}-assimp-${{ github.sha }}
 

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -39,12 +39,12 @@ jobs:
           ls-files -s src/external/assimp
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
-    - name: Configure Assimp
+      name: Configure Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
-    - name: Build Assimp
+      name: Build Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake --build . --config ${{env.BUILD_TYPE}}
       

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -35,7 +35,7 @@ jobs:
           ${{github.workspace}}\src\external\assimp\lib\release\assimp-vc143-mt.lib
           ${{github.workspace}}\src\external\assimp\include\assimp\config.h
         #Use the currently active commit SHA as the key
-        key: ${{ runner.os }}-assimp-${{ github.sha }}
+        key: ${{ runner.os }}-assimp-${{ hashFiles('**/package-lock.json') }}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
       name: Configure Assimp

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -35,8 +35,7 @@ jobs:
           ${{github.workspace}}/src/external/assimp/lib/release/assimp-vc143-mt.lib
           ${{github.workspace}}/src/external/assimp/include/assimp/config.h
         #Use the currently active commit SHA as the key
-        key: |
-          ls-files -s src/external/assimp
+        key: ${{ ls-files -s src/external/assimp }}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
       name: Configure Assimp

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -22,16 +22,12 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-
-  # There's probably a better way to do this, but I'm not familiar enough with github
-    - name: Retrieve Assimp SHA
-      run: |
-        echo "ASSIMP_SHA=$(git ls-files -s ${{github.workspace}}\src\external\assimp)" >> $GITHUB_OUTPUT
-      id: AssimpSHA
+    # There's probably a better way to do this, but I'm not familiar enough with github
+    - name: Retrieve Assimp Hash
+      uses: theowenyoung/folder-hash@v3
+      with:
+        path: ${{github.workspace}}/src/external/assimp
+      id: AssimpHash
 
     - name: Restore Assimp cache
       id: cache-assimp
@@ -40,8 +36,8 @@ jobs:
         path: |
           ${{github.workspace}}\src\external\assimp\lib\release\assimp-vc143-mt.lib
           ${{github.workspace}}\src\external\assimp\include\assimp\config.h
-        #Use the currently active commit SHA as the key
-        key: ${{ steps.AssimpHead.outputs.ASSIMP_SHA }}
+        #Use the currently active Assimp commit folder hash as the key
+        key: ${{ steps.AssimpHash.outputs.hash }}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Configure Assimp
@@ -52,6 +48,11 @@ jobs:
       name: Build Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake --build . --config ${{env.BUILD_TYPE}}
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
       
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -30,7 +30,7 @@ jobs:
   # There's probably a better way to do this, but I'm not familiar enough with github
     - name: Retrieve Assimp SHA
       run: |
-        echo "ASSIMP_SHA=$(git ls-files -s ./src/external/assimp)" >> $GITHUB_OUTPUT
+        echo "ASSIMP_SHA=$(git ls-files -s ${{github.workspace}}/src/external/assimp)" >> $GITHUB_OUTPUT
       id: AssimpSHA
 
     - name: Restore Assimp cache

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -27,6 +27,12 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
+  # There's probably a better way to do this, but I'm not familiar enough with github
+    - name: Retrieve Assimp SHA
+      run: |
+        echo "ASSIMP_SHA=$(ls-files -s src/external/assimp)" >> $GITHUB_OUTPUT
+      id: AssimpSHA
+
     - name: Restore Assimp cache
       id: cache-assimp
       uses: actions/cache@v4
@@ -35,14 +41,14 @@ jobs:
           ${{github.workspace}}\src\external\assimp\lib\release\assimp-vc143-mt.lib
           ${{github.workspace}}\src\external\assimp\include\assimp\config.h
         #Use the currently active commit SHA as the key
-        key: ${{ runner.os }}-assimp-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ steps.AssimpSHA.outputs.ASSIMP_SHA }}
 
-    - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
+    - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Configure Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
+    - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Build Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake --build . --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -27,10 +27,23 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
+    - name: Restore Assimp cache
+      id: cache-assimp
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{github.workspace}}/src/external/assimp/lib/release/assimp-vc143-mt.lib
+          ${{github.workspace}}/src/external/assimp/include/assimp/config.h
+        #Use the currently active commit SHA as the key
+        restore-keys: |
+          ls-files -s src/external/assimp
+
+    - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
     - name: Configure Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
+    - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
     - name: Build Assimp
       working-directory: ${{github.workspace}}/src/external/assimp
       run: cmake --build . --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -28,10 +28,10 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
   # There's probably a better way to do this, but I'm not familiar enough with github
-    - name: Retrieve Assimp head
+    - name: Retrieve Assimp SHA
       run: |
-        echo "ASSIMP_HEAD=$(git rev-parse HEAD:${{github.workspace}}\src\external\assimp)" >> $GITHUB_OUTPUT
-      id: AssimpHead
+        echo "ASSIMP_SHA=$(git ls-files -s ${{github.workspace}}\src\external\assimp)" >> $GITHUB_OUTPUT
+      id: AssimpSHA
 
     - name: Restore Assimp cache
       id: cache-assimp
@@ -40,8 +40,8 @@ jobs:
         path: |
           ${{github.workspace}}\src\external\assimp\lib\release\assimp-vc143-mt.lib
           ${{github.workspace}}\src\external\assimp\include\assimp\config.h
-        #Use the currently active commit as the key
-        key: ${{ steps.AssimpHead.outputs.ASSIMP_HEAD }}
+        #Use the currently active commit SHA as the key
+        key: ${{ steps.AssimpHead.outputs.ASSIMP_SHA }}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Configure Assimp

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -35,7 +35,7 @@ jobs:
           ${{github.workspace}}/src/external/assimp/lib/release/assimp-vc143-mt.lib
           ${{github.workspace}}/src/external/assimp/include/assimp/config.h
         #Use the currently active commit SHA as the key
-        restore-keys: |
+        key: |
           ls-files -s src/external/assimp
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -35,7 +35,7 @@ jobs:
           ${{github.workspace}}/src/external/assimp/lib/release/assimp-vc143-mt.lib
           ${{github.workspace}}/src/external/assimp/include/assimp/config.h
         #Use the currently active commit SHA as the key
-        key: ${{ ls-files -s src/external/assimp }}
+        key: ${{ runner.os }}-assimp-${{ github.sha }}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'false' }}
       name: Configure Assimp

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -28,10 +28,10 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
   # There's probably a better way to do this, but I'm not familiar enough with github
-    - name: Retrieve Assimp SHA
+    - name: Retrieve Assimp head
       run: |
-        echo "ASSIMP_SHA=$(git ls-files -s ${{github.workspace}}/src/external/assimp)" >> $GITHUB_OUTPUT
-      id: AssimpSHA
+        echo "ASSIMP_HEAD=$(git rev-parse HEAD:${{github.workspace}}\src\external\assimp)" >> $GITHUB_OUTPUT
+      id: AssimpHead
 
     - name: Restore Assimp cache
       id: cache-assimp
@@ -40,8 +40,8 @@ jobs:
         path: |
           ${{github.workspace}}\src\external\assimp\lib\release\assimp-vc143-mt.lib
           ${{github.workspace}}\src\external\assimp\include\assimp\config.h
-        #Use the currently active commit SHA as the key
-        key: ${{ steps.AssimpSHA.outputs.ASSIMP_SHA }}
+        #Use the currently active commit as the key
+        key: ${{ steps.AssimpHead.outputs.ASSIMP_HEAD }}
 
     - if: ${{ steps.cache-assimp.outputs.cache-hit != 'true' }}
       name: Configure Assimp

--- a/.github/workflows/Build-and-Pack.yml
+++ b/.github/workflows/Build-and-Pack.yml
@@ -1,5 +1,5 @@
 # This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml 
 name: Build and Pack
 
 on: 


### PR DESCRIPTION
Caches Assimp source lib based on folder hash.  It will update the cache if we move to a new build of Assimp.  Reduces our build time from 6 min to < 2 min.